### PR TITLE
🐛 fix(script): replace string(APPEND) with string(CONCAT)

### DIFF
--- a/cmake/targets/create_rtd_symlinks.cmake
+++ b/cmake/targets/create_rtd_symlinks.cmake
@@ -73,7 +73,7 @@ foreach(_LANGUAGE ${LANGUAGE_LIST})
         if (RES_VAR EQUAL 0)
             message("Created ReadTheDocs symlink '${_LANGUAGE_READTHEDOCS}' for language directory '${_LANGUAGE}'.")
         else()
-            string(APPEND FAILURE_REASON
+            string(CONCAT FAILURE_REASON
             "The command failed with fatal errors.\n"
             "    result:\n${RES_VAR}\n"
             "    stdout:\n${OUT_VAR}\n"

--- a/cmake/targets/install_requirements.cmake
+++ b/cmake/targets/install_requirements.cmake
@@ -155,14 +155,14 @@ execute_process(
     ERROR_VARIABLE  ERR_VAR ERROR_STRIP_TRAILING_WHITESPACE)
 if (RES_VAR EQUAL 0)
     if (ERR_VAR)
-        string(APPEND WARNING_REASON
+        string(CONCAT WARNING_REASON
         "The command succeeded with warnings.\n\n"
         "    result:\n\n${RES_VAR}\n\n"
         "    stderr:\n\n${ERR_VAR}")
         message("${WARNING_REASON}")
     endif()
 else()
-    string(APPEND FAILURE_REASON
+    string(CONCAT FAILURE_REASON
     "The command failed with fatal errors.\n"
     "    result:\n${RES_VAR}\n"
     "    stderr:\n${ERR_VAR}")
@@ -190,14 +190,14 @@ execute_process(
     ERROR_VARIABLE  ERR_VAR ERROR_STRIP_TRAILING_WHITESPACE)
 if (RES_VAR EQUAL 0)
     if (ERR_VAR)
-        string(APPEND WARNING_REASON
+        string(CONCAT WARNING_REASON
         "The command succeeded with warnings.\n\n"
         "    result:\n\n${RES_VAR}\n\n"
         "    stderr:\n\n${ERR_VAR}")
         message("${WARNING_REASON}")
     endif()
 else()
-    string(APPEND FAILURE_REASON
+    string(CONCAT FAILURE_REASON
     "The command failed with fatal errors.\n"
     "    result:\n${RES_VAR}\n"
     "    stderr:\n${ERR_VAR}")
@@ -250,14 +250,14 @@ execute_process(
     ERROR_VARIABLE  ERR_VAR ERROR_STRIP_TRAILING_WHITESPACE)
 if (RES_VAR EQUAL 0)
     if (ERR_VAR)
-        string(APPEND WARNING_REASON
+        string(CONCAT WARNING_REASON
         "The command succeeded with warnings.\n\n"
         "    result:\n\n${RES_VAR}\n\n"
         "    stderr:\n\n${ERR_VAR}")
         message("${WARNING_REASON}")
     endif()
 else()
-    string(APPEND FAILURE_REASON
+    string(CONCAT FAILURE_REASON
     "The command failed with fatal errors.\n"
     "    result:\n${RES_VAR}\n"
     "    stderr:\n${ERR_VAR}")
@@ -282,14 +282,14 @@ if (RES_VAR EQUAL 0)
     set(INSTALLED_PACKAGES  "${OUT_VAR}")
     message("${INSTALLED_PACKAGES}")
     if (ERR_VAR)
-        string(APPEND WARNING_REASON
+        string(CONCAT WARNING_REASON
         "The command succeeded with warnings.\n\n"
         "    result:\n\n${RES_VAR}\n\n"
         "    stderr:\n\n${ERR_VAR}")
         message("${WARNING_REASON}")
     endif()
 else()
-    string(APPEND FAILURE_REASON
+    string(CONCAT FAILURE_REASON
     "The command failed with fatal errors.\n"
     "    result:\n${RES_VAR}\n"
     "    stderr:\n${ERR_VAR}")

--- a/cmake/targets/sphinx_build_docs.cmake
+++ b/cmake/targets/sphinx_build_docs.cmake
@@ -168,14 +168,14 @@ foreach(_LANGUAGE ${LANGUAGE_LIST})
         ERROR_VARIABLE  ERR_VAR ERROR_STRIP_TRAILING_WHITESPACE)
     if (RES_VAR EQUAL 0)
         if (ERR_VAR)
-            string(APPEND WARNING_REASON
+            string(CONCAT WARNING_REASON
             "The command succeeded but had some warnings.\n\n"
             "    result:\n\n${RES_VAR}\n\n"
             "    stderr:\n\n${ERR_VAR}")
             message("${WARNING_REASON}")
         endif()
     else()
-        string(APPEND FAILURE_REASON
+        string(CONCAT FAILURE_REASON
         "The command failed with fatal errors.\n"
         "    result:\n${RES_VAR}\n"
         "    stderr:\n${ERR_VAR}")

--- a/cmake/targets/sphinx_update_pot.cmake
+++ b/cmake/targets/sphinx_update_pot.cmake
@@ -329,14 +329,14 @@ execute_process(
     ERROR_VARIABLE  ERR_VAR ERROR_STRIP_TRAILING_WHITESPACE)
 if (RES_VAR EQUAL 0)
     if (ERR_VAR)
-        string(APPEND WARNING_REASON
+        string(CONCAT WARNING_REASON
         "The command succeeded with warnings.\n\n"
         "    result:\n\n${RES_VAR}\n\n"
         "    stderr:\n\n${ERR_VAR}")
         message("${WARNING_REASON}")
     endif()
 else()
-    string(APPEND FAILURE_REASON
+    string(CONCAT FAILURE_REASON
     "The command failed with fatal errors.\n"
     "    result:\n${RES_VAR}\n"
     "    stderr:\n${ERR_VAR}")
@@ -355,7 +355,7 @@ execute_process(
 if (RES_VAR EQUAL 0)
     get_filename_component(SPHINX_LIB_DIR "${OUT_VAR}" DIRECTORY)
 else()
-    string(APPEND FAILURE_REASON
+    string(CONCAT FAILURE_REASON
     "The command failed with fatal errors.\n"
     "    result:\n${RES_VAR}\n"
     "    stdout:\n${OUT_VAR}\n"


### PR DESCRIPTION
Use string(CONCAT) instead of string(APPEND) to prevent accumulated warning and error messages from previous command iterations.

Synced from: https://github.com/localizethedocs/cmake-docs-l10n/commit/2d4655f8430ca057d285d3c94b5d59dec4e2d7c5